### PR TITLE
Pod install manifest diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,16 @@ checkout:
   post:
     # download ios-tools 
     - git submodule update --init
-    # run pods, carthage, match etc. need verbose to prevent timeouts in circle for slow activities
-    - bin/execute.sh setup --verbose:
+dependencies:
+  override:
+    # run pods, carthage, match etc. 
+    - bin/execute.sh setup:
         timeout: 3600 # 1 hr - note the : above and 4 spaces indent here
 test:
   override:
+    # start the simulator before running tests. this uses iPhone 6 (9.3)
+    - xcrun instruments -w '547B1B63-3F66-4E5B-8001-F78F2F1CDEA7' || true
+    - sleep 15
     - bin/execute.sh test
     - mv build/reports/* $CIRCLE_TEST_REPORTS
 deployment:

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -8,6 +8,9 @@ function setup() {
   # This is the bundle command that circle uses 
   bundle check || bundle install --jobs 4 --retry 3
 
+  # Fix for circle error code 65?
+  diff Podfile.lock Pods/Manifest.lock > /dev/null || bundle exec pod install
+
   # pod install may take 25 mins on circle if it has to download the master spec repo             
   bundle exec pod check || bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
 

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -5,8 +5,12 @@ function setup() {
     verboseArg='--verbose'
   fi
 
-#  gem install bundler
-#  bundle install $verboseArg
+  # This is the bundle command that circle uses 
+  bundle check || bundle install --jobs 4 --retry 3
+
+  # pod install may take 25 mins on circle if it has to download the master spec repo             
+  bundle exec pod check || bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
+
   if [[ -f Matchfile ]]; then
     bundle exec match development --readonly $verboseArg
   fi
@@ -17,8 +21,6 @@ function setup() {
   fi
 
   comp_deinit
-
-#  bundle exec pod check || bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
 
   if [[ -f Cartfile ]]; then
     if [[ -f Carthage/Build.tar.gz ]]; then

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -8,7 +8,8 @@ function setup() {
   # This is the bundle command that circle uses 
   bundle check || bundle install --jobs 4 --retry 3
 
-  # Fix for circle error code 65?
+  # pod check doesn't seem to know when the Pods cache is out of date on CircleCI, 
+  # so force an install if a pod was updated by a developer
   diff Podfile.lock Pods/Manifest.lock > /dev/null || bundle exec pod install
 
   # pod install may take 25 mins on circle if it has to download the master spec repo             

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -5,8 +5,8 @@ function setup() {
     verboseArg='--verbose'
   fi
 
-  gem install bundler
-  bundle install $verboseArg
+#  gem install bundler
+#  bundle install $verboseArg
   if [[ -f Matchfile ]]; then
     bundle exec match development --readonly $verboseArg
   fi
@@ -18,7 +18,7 @@ function setup() {
 
   comp_deinit
 
-  bundle exec pod check || bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
+#  bundle exec pod check || bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
 
   if [[ -f Cartfile ]]; then
     if [[ -f Carthage/Build.tar.gz ]]; then


### PR DESCRIPTION
- run pods business ourselves so we can override the timeout and so we have a single setup.sh bootstrapping script we can run locally or in CI.
- use pod check to prevent an unnecessary spec master repo update (ALL projects must add cocoapods-check to their Gemfile)
- start the simulator before UI tests, since some people said that they had UI tests failing with error code 65 when the simulator took too long to start. we still have this issue, but it doesn't hurt to be defensive and it only costs 15 seconds
- diff the Podfile.lock with the Manifest.lock, since circle caches the /Pods directory, and pod check doesn't seem to pick up on the fact that the Manifest.lock is out of date, and says everything's up to date, however during the build xcode will also do this diff, and fail if it's different. I've raised an issue on the cocoapods-check github...