### PR TITLE
Remove git hooks for Carthage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ caching of the pod master spec repo, hence in `circle.yml` you will see the `bin
 which skips `bundle install` and `bundle exec pod install` commands.
 
 If using **Carthage**, the standard `bin/execute.sh setup` will handle the download and building of frameworks 
-specified in the Cartfile. They will still need to be added to the Xcode project manually, if not yet done so.
+specified in the Cartfile. They will still need to be added to the Xcode project manually, if not yet done so. If the `/Carthage` directory already exists (ie. was cached by CI) a copy of the `Cartfile.resolved` stored in `/Carthage` will detected if the `Cartfile` has changed and only build Carthage dependencies if they're out of date or missing.
 
-Git hooks will tar up the Carthage build output and commit it, and untar it on checkout, automagically!
+NOTE: When updating Carthage libraries and rebuilding, it is best practise to keep this in a separate commit/PR to keep the noise out of code reviews.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ dependencies:
   post:
     # run match after Circle runs bundler and pods
     - bin/execute.sh setup --no-pods
+  cache_directories:
+    - "Carthage"
 test:
   override:
     - bin/execute.sh test --restart-simulator

--- a/components/dependencies.sh
+++ b/components/dependencies.sh
@@ -18,9 +18,14 @@ function pod_install() {
 function carthage_bootstrap() {
   comp_init 'dependencies'
   if [[ -f Cartfile ]]; then
-    check_deps 'carthage'
-    msg 'Installing Carthage packages'
-    run_carthage bootstrap
+    if ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
+      check_deps 'carthage'
+      msg 'Installing Carthage packages'
+      run_carthage bootstrap
+      cp Cartfile.resolved Carthage
+    else
+      msg 'Carthage packages up to date - skipping'
+    fi
   fi
   comp_deinit
 }

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -24,19 +24,5 @@ function setup() {
 
   comp_deinit
 
-  if [[ -f Cartfile ]]; then
-    if [[ -f Carthage/Build.tar.gz ]]; then
-      .git/hooks/post-checkout
-    fi
-    if [[ ! -d "Carthage/Build" ]]; then
-      carthage_bootstrap
-    fi
-    .git/hooks/pre-commit
-  fi
-}
-
-function symlinkGitHooks() {
-  hooksDir=$project_dir/.git/hooks
-  mkdir -p $hooksDir
-  ln -s ../../bin/git-hooks/{pre-commit,post-checkout} $hooksDir
+  carthage_bootstrap
 }

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -22,11 +22,6 @@ function setup() {
     bundle exec fastlane match appstore --readonly $verboseArg
   fi
 
-  if [[ -f Cartfile && ! -f .git/hooks/post-checkout ]]; then
-    msg 'Installing Git hooks'
-    symlinkGitHooks
-  fi
-
   comp_deinit
 
   if [[ -f Cartfile ]]; then


### PR DESCRIPTION
Cache Carthage on Circle, and use the cached `Carthage.resolved` file to determine whether a build of Carthage dependencies is necessary.