### PR TITLE
update carthage ignore policy

### DIFF
--- a/assets/gitignore-ios.txt
+++ b/assets/gitignore-ios.txt
@@ -20,6 +20,13 @@ xcuserdata/
 *.xcscmblueprint
 *.DS_Store
 
+# Env variables file
+.env
+!.env.sample
+
+# Buid products
+*.xcarchive
+
 ## Obj-C/Swift specific
 *.hmap
 *.ipa
@@ -28,6 +35,9 @@ xcuserdata/
 # CocoaPods
 Pods/
 
-# Carthage
-Carthage/Build/
-Carthage/Checkouts/
+# Ignore Carthage checkouts and builds
+Carthage/
+
+# Override Carthage ignore for the Cartfile.resolved, which we can use to determine 
+# if rebuilding Carthage dependencies is necessary or not
+!Carthage/Cartfile.resolved


### PR DESCRIPTION
i think on buildkite git `git clean -fdq` command was deleting directories not covered by `.gitignore` and the fact that we only specified `Carthage/Builds` and `Carthage/Checkouts` meant that the `Carthage` folder (and `Carthage/Cartfile.resolved` which ios-tools now uses to determine whether it needs to run carthage) was being lost.