### PR TITLE
Add support for build numbers in CI

### DIFF
--- a/components/deployment.sh
+++ b/components/deployment.sh
@@ -26,6 +26,11 @@ function itunes_connect() {
     --scheme "$scheme" \
     $clean_build
 
+  if [[ $build_number ]]; then
+    msg "Tagging build as $build_number"
+    git tag -a build-$build_number -m "Added by ios-tools"
+  fi
+
   msg "Submitting to iTunes Connect"
   bundle exec fastlane deliver run \
     --app_identifier "$BUNDLE_IDENTIFIER" \

--- a/execute.sh
+++ b/execute.sh
@@ -41,6 +41,7 @@ function script_usage() {
     clean                           Remove DerivedData directory
     itunes-connect                  Send a new build to iTunes Connect
       -s|--scheme                     The scheme to build (default: $PROD_SCHEME)
+      -b|--build-number               If provided tags the git commit with the build number
 
   Common options:
     -nc|--no-colour                 Disable usage of coloured script status output
@@ -78,6 +79,11 @@ function parse_params() {
       -ng|--no-git)
         check_tasksel 'update'
         no_git=true
+        ;;
+      -b|--build-number)
+        check_tasksel 'itunes-connect'
+        build_number="$1"
+        shift
         ;;
       -s|--scheme)
         check_tasksel 'itunes-connect'

--- a/scripts/bundle_version.sh
+++ b/scripts/bundle_version.sh
@@ -1,8 +1,16 @@
+#!/usr/bin/env bash
+
 git=$(sh /etc/profile; which git)
-number_of_commits=$("$git" rev-list HEAD --count)
 
-bundle_version=$number_of_commits
+bundle_version=$1
 
+if [[ -z $bundle_version ]]; then
+  # If not provided as a command line argument, use the number of commits on the current branch
+  bundle_version=$("$git" rev-list HEAD --count)
+fi
+
+echo $bundle_version
+exit
 target_plist="$TARGET_BUILD_DIR/$INFOPLIST_PATH"
 dsym_plist="$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist"
 


### PR DESCRIPTION
Modified bundle_version script to accept a provided build number, added tagging to the itunes connect script