### PR TITLE
Added flag to specify git repo root

### DIFF
--- a/components/setup.sh
+++ b/components/setup.sh
@@ -13,7 +13,7 @@ function setup() {
     bundle exec pod install $verboseArg || bundle exec pod install --repo-update $verboseArg
   fi
 
-  if [[ -f Matchfile ]]; then
+  if [[ -f Matchfile ]] || [[ -f fastlane/Matchfile ]]; then
     bundle exec fastlane match development --readonly $verboseArg
     bundle exec fastlane match appstore --readonly $verboseArg
   fi
@@ -27,9 +27,12 @@ function setup() {
 }
 
 function symlinkGitHooks() {
-  hooksDir="$project_dir"/.git/hooks
+  if [[ -z "$git_root" ]]; then
+    git_root="$project_dir"
+  fi
+  hooksDir="$git_root"/.git/hooks
   mkdir -p "$hooksDir"
-  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-checkout
-  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-merge
+  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-checkout.ios-tools
+  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-merge.ios-tools
 }
 

--- a/components/setup.sh
+++ b/components/setup.sh
@@ -32,7 +32,7 @@ function symlinkGitHooks() {
   fi
   hooksDir="$git_root"/.git/hooks
   mkdir -p "$hooksDir"
-  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-checkout.ios-tools
-  ln -fs ../../bin/git-hooks/submodule-update "$hooksDir"/post-merge.ios-tools
+  ln -fs "$project_dir"/bin/git-hooks/submodule-update "$hooksDir"/post-checkout.ios-tools
+  ln -fs "$project_dir"/bin/git-hooks/submodule-update "$hooksDir"/post-merge.ios-tools
 }
 

--- a/execute.sh
+++ b/execute.sh
@@ -45,7 +45,8 @@ function script_usage() {
 
   Common options:
     -nc|--no-colour                 Disable usage of coloured script status output
-    --configuration                 Configuration to use"
+    --configuration                 Configuration to use
+    -g|--git-root                   Specifies the path to the root of the repository (default: ./../)"
 }
 
 # Nom the parameters
@@ -88,6 +89,10 @@ function parse_params() {
       -s|--scheme)
         check_tasksel 'itunes-connect'
         scheme="$1"
+        shift
+        ;;
+      -g|--git-root)
+        git_root="$1"
         shift
         ;;
       -v|--verbose)


### PR DESCRIPTION
React Native has a root-level folder called `ios` where the ios project lives, but ios-tools relies on the `bin` directory being top-level in the repo. This PR provides a flag to allow you to specify the path to the root of the repo.

It also adds a suffix on the git hooks added, to avoid collisions with other hooks